### PR TITLE
Refactor auth middleware to use a standard pattern

### DIFF
--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,10 +1,10 @@
 const jwt = require('jsonwebtoken');
 const User = require('../models/User');
 
+// This middleware authenticates the user via JWT
 const auth = async (req, res, next) => {
   try {
     const token = req.header('Authorization')?.replace('Bearer ', '');
-    
     if (!token) {
       return res.status(401).json({ message: 'Access denied. No token provided.' });
     }
@@ -13,27 +13,25 @@ const auth = async (req, res, next) => {
     const user = await User.findById(decoded.userId);
     
     if (!user) {
-      return res.status(401).json({ message: 'Invalid token.' });
+      return res.status(401).json({ message: 'Invalid token. User not found.' });
     }
 
     req.user = user;
     next();
   } catch (error) {
+    // Catches JWT verification errors (e.g., expired, malformed)
     res.status(401).json({ message: 'Invalid token.' });
   }
 };
 
-const adminAuth = async (req, res, next) => {
-  try {
-    await auth(req, res, () => {
-      if (req.user.role !== 'admin') {
-        return res.status(403).json({ message: 'Access denied. Admin only.' });
-      }
-      next();
-    });
-  } catch (error) {
-    res.status(401).json({ message: 'Authentication failed.' });
+// This middleware checks if the authenticated user is an admin
+const isAdmin = (req, res, next) => {
+  // Assumes 'auth' middleware has been called before this
+  if (req.user && req.user.role === 'admin') {
+    next();
+  } else {
+    res.status(403).json({ message: 'Access denied. Admin privileges required.' });
   }
 };
 
-module.exports = { auth, adminAuth };
+module.exports = { auth, isAdmin };

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,11 +1,11 @@
 const express = require('express');
 const User = require('../models/User');
-const { adminAuth } = require('../middleware/auth');
+const { auth, isAdmin } = require('../middleware/auth');
 
 const router = express.Router();
 
 // Get all users (admin only)
-router.get('/users', adminAuth, async (req, res) => {
+router.get('/users', [auth, isAdmin], async (req, res) => {
   try {
     const users = await User.find({ role: 'user' })
       .select('-password')
@@ -19,7 +19,7 @@ router.get('/users', adminAuth, async (req, res) => {
 });
 
 // Update user status (admin only)
-router.patch('/users/:id', adminAuth, async (req, res) => {
+router.patch('/users/:id', [auth, isAdmin], async (req, res) => {
   try {
     const { id } = req.params;
     const { status } = req.body;
@@ -56,7 +56,7 @@ router.patch('/users/:id', adminAuth, async (req, res) => {
 });
 
 // Get admin dashboard stats
-router.get('/stats', adminAuth, async (req, res) => {
+router.get('/stats', [auth, isAdmin], async (req, res) => {
   try {
     const totalUsers = await User.countDocuments({ role: 'user' });
     const pendingUsers = await User.countDocuments({ role: 'user', status: 'pending' });


### PR DESCRIPTION
The previous `adminAuth` middleware combined authentication and authorization in a non-standard and potentially confusing way by calling the `auth` middleware within it. This could lead to subtle bugs and was hard to reason about.

This change refactors the middleware into two distinct, chained functions:
- `auth`: Handles JWT-based authentication.
- `isAdmin`: Handles authorization by checking for the 'admin' role.

The admin routes have been updated to use this new, more secure, and conventional `[auth, isAdmin]` middleware chain. This improves the security, clarity, and maintainability of the authorization logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Clearer authentication error messages: 401 for invalid/expired tokens; 403 with “Access denied. Admin privileges required.” when permissions are insufficient.
* Refactor
  * Split admin access into separate authentication and admin-check steps; admin routes now apply both, improving consistency across admin endpoints (users list, user update, stats).
* Documentation
  * Added clarifying comments in the authentication middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->